### PR TITLE
Enhancement/op-4521_color_picker_alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{jsx,ts,tsx}'",
-    "format": "prettier --write src/**/*.{js,jsx,css} --config ./.prettierrc",
+    "format": "prettier --write src/**/*.{js,jsx} --config ./.prettierrc",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -23,6 +23,8 @@ import {
 import PrimeReactForm from '/src/primereact'
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
+import { InputColorAlpha } from './components'
+import { useState } from 'react'
 
 const customers = [
   { name: 'Customer 1', country: 'Country 1', representative: 'Representative 1' },
@@ -34,31 +36,43 @@ const customers = [
   { name: 'Customer 7', country: 'Country 7', representative: 'Representative 7' },
 ]
 
-const DemoForm = () => (
-  <FormLayout>
-    <FormRow label="Label">
-      <InputText placeholder="Some text..." pattern="[a-zA-Z1-9_]{2,16}" />
-    </FormRow>
-    <FormRow label="Error input">
-      <InputText placeholder="Error input" className="error" />
-    </FormRow>
-    <FormRow label="Disabled input">
-      <InputText placeholder="Disabled input" disabled={true} />
-    </FormRow>
-    <FormRow label="Number input">
-      <InputNumber placeholder="Number input" min={0} max={10} />
-    </FormRow>
-    <FormRow label="Color input">
-      <InputColor placeholder="Color input" />
-    </FormRow>
-    <FormRow label="Text area">
-      <InputTextarea placeholder="Some text..." rows={8} />
-    </FormRow>
-    <FormRow label="Switch">
-      <InputSwitch />
-    </FormRow>
-  </FormLayout>
-)
+const DemoForm = () => {
+  // demo for color picker
+  const [color, setColor] = useState([0.25, 0.5, 0.3, 0.99])
+
+  return (
+    <FormLayout>
+      <FormRow label="Label">
+        <InputText placeholder="Some text..." pattern="[a-zA-Z1-9_]{2,16}" />
+      </FormRow>
+      <FormRow label="Error input">
+        <InputText placeholder="Error input" className="error" />
+      </FormRow>
+      <FormRow label="Disabled input">
+        <InputText placeholder="Disabled input" disabled={true} />
+      </FormRow>
+      <FormRow label="Number input">
+        <InputNumber placeholder="Number input" min={0} max={10} />
+      </FormRow>
+      <FormRow label="Color input">
+        <InputColor placeholder="Color input" />
+      </FormRow>
+      <FormRow label="Color Alpha input">
+        <InputColorAlpha
+          placeholder="Color Alpha input"
+          values={color}
+          onChange={(v) => setColor(v)}
+        />
+      </FormRow>
+      <FormRow label="Text area">
+        <InputTextarea placeholder="Some text..." rows={8} />
+      </FormRow>
+      <FormRow label="Switch">
+        <InputSwitch />
+      </FormRow>
+    </FormLayout>
+  )
+}
 
 const App = () => {
   return (

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ import { Panel, TablePanel, ScrollPanel } from './layout/panels'
 import { Shade, LoaderShade } from './overlay/shade'
 import { InputText, InputNumber, InputTextarea, InputPassword, InputColor } from './input'
 import { InputSwitch } from './input/switch'
+import { InputColorAlpha } from './input/colorPicker'
 
 import './index.sass'
 
@@ -29,4 +30,5 @@ export {
   InputSwitch,
   TablePanel,
   ScrollPanel,
+  InputColorAlpha,
 }

--- a/src/components/input/colorPicker.jsx
+++ b/src/components/input/colorPicker.jsx
@@ -1,0 +1,132 @@
+import styled from 'styled-components'
+import { InputNumber } from '.'
+
+// convert a hex value to float between 0-1
+const hexToFloat = (hex) => {
+  // round to 2 decimals\
+  var r = Math.round((parseInt(hex.slice(1, 3), 16) / 255) * 100) / 100,
+    g = Math.round((parseInt(hex.slice(3, 5), 16) / 255) * 100) / 100,
+    b = Math.round((parseInt(hex.slice(5, 7), 16) / 255) * 100) / 100
+
+  return [r, g, b]
+}
+
+const floatToHex = (float) => {
+  return (
+    '#' +
+    (
+      (1 << 24) |
+      (Math.round(float[0] * 255) << 16) |
+      (Math.round(float[1] * 255) << 8) |
+      Math.round(float[2] * 255)
+    )
+      .toString(16)
+      .slice(1)
+  )
+}
+
+// values = array of floats [0.5, 0.25, 0.6, 1]
+const colorPicker = ({ style, className, values, onChange }) => {
+  const channels = ['r', 'g', 'b', 'a']
+
+  const handleOnChange = (e) => {
+    e.preventDefault()
+    const { id, value } = e.target
+    // fist check value is a number and convert to float
+    if (isNaN(value)) {
+      return console.error('Value is not a number')
+    }
+    // create copy of current values
+    let newValues = [...values]
+    // delete updating value
+    newValues.splice(channels.indexOf(id), 1, parseFloat(value))
+
+    onChange && onChange(newValues)
+  }
+
+  const handlePickerOnChange = (e) => {
+    e.preventDefault()
+    // convert hex to rgb
+    const newValues = hexToFloat(e.target.value)
+    // insert alpha
+    newValues.push(values[3])
+
+    // update values state
+    onChange && onChange(newValues)
+  }
+
+  return (
+    <div style={style} className={className}>
+      <input type="color" onChange={handlePickerOnChange} value={floatToHex(values)} />
+      {values &&
+        values.map((value, i) => {
+          const c = channels[i]
+
+          return (
+            <div key={c}>
+              <label htmlFor={c}>{c.toUpperCase()}</label>
+              <InputNumber
+                id={c}
+                min={0}
+                max={1}
+                value={value}
+                step={'any'}
+                onChange={handleOnChange}
+              />
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+const InputColorAlpha = styled(colorPicker)`
+  color: var(--color-text);
+  border: 1px solid var(--color-grey-03);
+  background-color: var(--color-grey-00);
+  border-radius: var(--base-input-border-radius);
+  /* min-height: var(--base-input-size); */
+  /* max-height: var(--base-input-size); */
+  display: flex;
+  align-items: center;
+
+  /* padding: 5px; */
+
+  width: fit-content;
+
+  /* reset color input */
+  input[type='color'] {
+    border: none;
+    background-color: unset;
+    padding: 0;
+    /* offset to padding and border */
+    width: 38px;
+    margin: 5px;
+  }
+
+  input[type='number'] {
+    width: 50px;
+    margin: 5px;
+  }
+
+  &:focus {
+    outline: 1px solid var(--color-hl-00);
+  }
+
+  &.error,
+  &:invalid {
+    border-color: var(--color-hl-error);
+  }
+
+  &:disabled {
+    color: var(--color-text-dim);
+    background-color: var(--input-disabled-background-color);
+    border-color: var(--input-disabled-border-color);
+    font-style: italic;
+    cursor: not-allowed;
+  }
+`
+
+// colorPicker.propTypes = {}
+
+export { InputColorAlpha }

--- a/src/components/input/colorPicker.jsx
+++ b/src/components/input/colorPicker.jsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 import { InputNumber } from '.'
 
 // convert a hex value to float between 0-1
 const hexToFloat = (hex) => {
-  // round to 2 decimals\
+  // round to 2 decimals
   var r = Math.round((parseInt(hex.slice(1, 3), 16) / 255) * 100) / 100,
     g = Math.round((parseInt(hex.slice(3, 5), 16) / 255) * 100) / 100,
     b = Math.round((parseInt(hex.slice(5, 7), 16) / 255) * 100) / 100
@@ -11,6 +12,7 @@ const hexToFloat = (hex) => {
   return [r, g, b]
 }
 
+// convert an array of floats [0-1, 0-1, 0-1] to HEX #24C7BD
 const floatToHex = (float) => {
   return (
     '#' +
@@ -25,8 +27,8 @@ const floatToHex = (float) => {
   )
 }
 
-// values = array of floats [0.5, 0.25, 0.6, 1]
-const colorPicker = ({ style, className, values, onChange }) => {
+// REACT FUNCTIONAL COMPONENT
+const colorPickerAlpha = ({ style, className, values, onChange }) => {
   const channels = ['r', 'g', 'b', 'a']
 
   const handleOnChange = (e) => {
@@ -38,9 +40,9 @@ const colorPicker = ({ style, className, values, onChange }) => {
     }
     // create copy of current values
     let newValues = [...values]
-    // delete updating value
+    // replace new colour  value in array
     newValues.splice(channels.indexOf(id), 1, parseFloat(value))
-
+    // update values state
     onChange && onChange(newValues)
   }
 
@@ -50,7 +52,6 @@ const colorPicker = ({ style, className, values, onChange }) => {
     const newValues = hexToFloat(e.target.value)
     // insert alpha
     newValues.push(values[3])
-
     // update values state
     onChange && onChange(newValues)
   }
@@ -80,7 +81,21 @@ const colorPicker = ({ style, className, values, onChange }) => {
   )
 }
 
-const InputColorAlpha = styled(colorPicker)`
+// values prop type checks it's an array of 4 floats
+colorPickerAlpha.propTypes = {
+  style: PropTypes.object,
+  className: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  values: (props, propName) =>
+    !Array.isArray(props[propName]) ||
+    props[propName].length != 4 ||
+    props[propName].some((v) => typeof v !== 'number')
+      ? new Error(`${propName} needs to be an array of four numbers`)
+      : null,
+}
+
+// styles
+const InputColorAlpha = styled(colorPickerAlpha)`
   color: var(--color-text);
   border: 1px solid var(--color-grey-03);
   background-color: var(--color-grey-00);
@@ -126,7 +141,5 @@ const InputColorAlpha = styled(colorPicker)`
     cursor: not-allowed;
   }
 `
-
-// colorPicker.propTypes = {}
 
 export { InputColorAlpha }


### PR DESCRIPTION
### Brief description
Add alpha support to the color picker input.

### Description
Created a new component with alpha support for the color picker by extending the default input and including 4 new number inputs for "RGBA". The component receives an array of floats for each channel (normally 0-1) and returns the same when onChange is fired. The native input color picker remains the same but two new functions have been created `hexToFloat` and `floatToHex` to handle the native input only supporting hex strings.

<img width="471" alt="image" src="https://user-images.githubusercontent.com/49156310/206130436-814623e3-3050-4771-b663-3d99254a3a37.png">

### Questions
- The original "no alpha" color picker input only supports hex strings and isn't inline with InputColorAlpha.
- It might be worth merging these two components together and either letting the user or developer choose if alpha channels are needed.
- The same with showing the float values, should the 4 number inputs always be visible?
- At the moment you can't paste colors into the input (in any format).
- We may need an dropdown menu that lets you switch between formats. 

### Testing

- Use the Demo Form.