### PR TITLE
Enhancement: Color Picker Quick Select

### DIFF
--- a/src/components/button/colorPickerPreview.jsx
+++ b/src/components/button/colorPickerPreview.jsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+const Wrapper = styled.div`
+  position: relative;
+  display: grid;
+  margin-right: 5px;
+  min-height: var(--base-input-size);
+  max-height: var(--base-input-size);
+  max-width: var(--base-input-size);
+  min-width: var(--base-input-size);
+
+  & > * {
+    grid-row: 1;
+    grid-column: 1;
+
+    border-radius: var(--base-input-border-radius);
+  }
+`
+
+const Input = styled.input`
+  /* if disabled remove click events */
+  pointer-events: ${(props) => props.disabled && 'none'};
+  cursor: pointer;
+
+  width: 100%;
+  height: 100%;
+
+  &:focus {
+    outline: 1px solid var(--color-hl-00);
+  }
+`
+
+const Checkerboard = styled.span`
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+
+  /* DOES NOT SUPPORT IE or pre-Chromium Edge */
+  background: repeating-conic-gradient(#808080 0% 25%, rgb(51 51 51) 0% 50%) 50% / 15px 15px;
+`
+
+const buttonStyles = css`
+  color: var(--color-text);
+  border: 1px solid var(--color-grey-03);
+  cursor: pointer;
+
+  /* if disabled remove click events */
+  pointer-events: ${(props) => props.disabled && 'none'};
+
+  &:focus {
+    outline: 1px solid var(--color-hl-00);
+  }
+
+  &.error,
+  &:invalid {
+    border-color: var(--color-hl-error);
+  }
+`
+
+const ColorButton = styled.button`
+  ${buttonStyles}
+`
+
+const ColorPickerPreview = ({ onClick, onChange, backgroundColor, value }) => {
+  return (
+    <Wrapper>
+      <Input
+        type="color"
+        disabled={!onChange}
+        tabIndex={!onChange ? -1 : 0}
+        onChange={onChange && onChange}
+        value={value}
+      />
+      <Checkerboard />
+      <ColorButton
+        style={{
+          backgroundColor: backgroundColor,
+          pointerEvents: onClick ? 'auto' : 'none',
+        }}
+        disabled={!onClick}
+        tabIndex={!onClick ? -1 : 0}
+        onClick={onClick}
+      />
+    </Wrapper>
+  )
+}
+
+export default ColorPickerPreview

--- a/src/components/button/colorPickerPreview.jsx
+++ b/src/components/button/colorPickerPreview.jsx
@@ -44,6 +44,7 @@ const buttonStyles = css`
   color: var(--color-text);
   border: 1px solid var(--color-grey-03);
   cursor: pointer;
+  margin: 0;
 
   /* if disabled remove click events */
   pointer-events: ${(props) => props.disabled && 'none'};

--- a/src/components/button/colorPickerPreview.jsx
+++ b/src/components/button/colorPickerPreview.jsx
@@ -62,7 +62,7 @@ const ColorButton = styled.button`
   ${buttonStyles}
 `
 
-const ColorPickerPreview = ({ onClick, onChange, backgroundColor, value }) => {
+const ColorPickerPreview = ({ onClick, onChange, backgroundColor, value, onBlur }) => {
   return (
     <Wrapper>
       <Input
@@ -71,6 +71,7 @@ const ColorPickerPreview = ({ onClick, onChange, backgroundColor, value }) => {
         tabIndex={!onChange ? -1 : 0}
         onChange={onChange && onChange}
         value={value}
+        onBlur={onBlur}
       />
       <Checkerboard />
       <ColorButton

--- a/src/components/input/colorPicker.jsx
+++ b/src/components/input/colorPicker.jsx
@@ -171,9 +171,18 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
   let previewBG = hex
   if (alpha) previewBG = hex + (localAlpha > 0 ? int8ToHex(floatToInt8(localAlpha)) : '00')
 
+  // check if dialog is actually required
+  const useDialog = alpha || ['uint16', 'float'].includes(format)
+
   return (
     <div style={style} className={className}>
-      <ColorPickerPreview onClick={handleOpenDialog} backgroundColor={previewBG} value={hex} />
+      <ColorPickerPreview
+        onClick={useDialog ? handleOpenDialog : undefined}
+        backgroundColor={previewBG}
+        value={hex}
+        onChange={!useDialog ? handleColorInputOnChange : undefined}
+        onBlur={() => !useDialog && handleCloseDialog()}
+      />
       {dialogOpen && (
         <Dialog header={DialogTitle} onHide={handleCloseDialog}>
           <ColorInputs>

--- a/src/components/input/colorPicker.jsx
+++ b/src/components/input/colorPicker.jsx
@@ -10,6 +10,7 @@ import toHexColor from '../../helpers/toHexColor'
 import validateHexColor from '../../helpers/validateHexColor'
 import ColorPickerPreview from '../button/colorPickerPreview'
 import floatToInt16 from '../../helpers/floatToInt16'
+import { Button } from '../button'
 
 const ColorInputs = styled.div`
   display: flex;
@@ -24,6 +25,13 @@ const ColorInputs = styled.div`
     width: 70px;
     margin: 5px;
   }
+`
+
+const Confirmations = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: var(--base-gap-large);
+  margin-top: 12px;
 `
 
 const formatsConfig = {
@@ -121,7 +129,7 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
     setDialogOpen(true)
   }
 
-  const handleCloseDialog = () => {
+  const handleConfirmDialog = () => {
     // close dialog
     setDialogOpen(false)
     let newState
@@ -136,6 +144,7 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
       // validate all numbers
       newState = newState.map((v, i) => (isNaN(v) || v === '' ? initValue[i] : parseFloat(v)))
     }
+    console.log(localValue)
 
     // update local state
     setLocalValue(newState)
@@ -164,6 +173,15 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
     onChange(event)
   }
 
+  const handleCancelDialog = () => {
+    console.log('cancelling')
+    // reset local variables
+    setLocalValue(initValue)
+    setLocalAlpha(initAlpha)
+    // close dialog
+    setDialogOpen(false)
+  }
+
   const DialogTitle = `Colour Picker (${format.charAt(0).toUpperCase() + format.slice(1)})`
 
   const hex = isHex ? localValue : toHexColor(localValue, format)
@@ -181,10 +199,10 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
         backgroundColor={previewBG}
         value={hex}
         onChange={!useDialog ? handleColorInputOnChange : undefined}
-        onBlur={() => !useDialog && handleCloseDialog()}
+        onBlur={() => !useDialog && handleConfirmDialog()}
       />
       {dialogOpen && (
-        <Dialog header={DialogTitle} onHide={handleCloseDialog}>
+        <Dialog header={DialogTitle} onHide={handleCancelDialog}>
           <ColorInputs>
             <ColorPickerPreview
               onChange={handleColorInputOnChange}
@@ -240,6 +258,10 @@ const InputColor = ({ style, className, value, onChange, alpha, format = 'hex' }
               </div>
             )}
           </ColorInputs>
+          <Confirmations>
+            <Button label={'Cancel'} onClick={handleCancelDialog} />
+            <Button label={'Apply'} onClick={handleConfirmDialog} />
+          </Confirmations>
         </Dialog>
       )}
     </div>

--- a/src/components/overlay/dialog.jsx
+++ b/src/components/overlay/dialog.jsx
@@ -93,7 +93,7 @@ const Dialog = ({
 
   return (
     <Shade className="dialog-shade" onClick={onShadeClick} onKeyDown={onKeyDown}>
-      <DialogWindow className={className} style={style} onKeyDown={onKeyDown} tabIndex={0}>
+      <DialogWindow className={className} style={style} onKeyDown={onKeyDown} tabIndex={-1}>
         {headerComp}
         <DialogBody style={bodyStyle}>{children}</DialogBody>
         {footerComp}

--- a/src/components/overlay/dialog.jsx
+++ b/src/components/overlay/dialog.jsx
@@ -17,12 +17,12 @@ const Shade = styled.div`
 `
 
 const DialogWindow = styled.div`
-  padding: 6px;
   background-color: var(--color-grey-01);
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 12px;
+  padding: 12px;
   min-width: 200px;
   min-height: 100px;
   max-width: 85%;
@@ -35,7 +35,6 @@ const DialogWindow = styled.div`
 `
 
 const BaseDialogEdge = styled.div`
-  padding: 12px 6px;
   display: flex;
   flex-direction: row;
   gap: 6px;
@@ -51,12 +50,10 @@ const DialogFooter = styled(BaseDialogEdge)`
 `
 
 const DialogBody = styled.div`
-  padding: 12px 6px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+
   flex-grow: 1;
-  overflow: auto;
 `
 
 const Dialog = ({

--- a/src/helpers/floatToInt16.js
+++ b/src/helpers/floatToInt16.js
@@ -1,0 +1,3 @@
+const floatToInt16 = (value) => Math.max(Math.min(Math.round(value * 65535), 65535), 0)
+
+export default floatToInt16


### PR DESCRIPTION
### Brief Description

Include the native color picker input as an easy way to pick a quick color.

### Description

A custom "color preview" component has been created to show the selected color and alpha whilst also acting as a color picker input for fast color selection.

<img width="417" alt="image" src="https://user-images.githubusercontent.com/49156310/206511737-1861f0bc-aaf7-4ab1-831f-d2a7870f8db2.png">

- Confirmation buttons added
- Picker uses "basic" mode when format is `hex | uint8` and `alpha = false`.

<img width="420" alt="image" src="https://user-images.githubusercontent.com/49156310/206513572-41421c4c-7486-4fd9-8d29-73a2c5722e8d.png">


### TODO
- Pasting in whole colors difficult. (Paste in 255,234,123)
- Buttons aren't included in tab index for safari
 